### PR TITLE
Added support for sending RSSI from radio to STM32

### DIFF
--- a/interface/esb.h
+++ b/interface/esb.h
@@ -44,7 +44,7 @@ typedef struct esbPacket_s {
     uint8_t data[32];
   } __attribute__((packed));
   /* Written by the radio interrupt routine */
-  int rssi;
+  uint32_t rssi;
   unsigned int crc;
 } EsbPacket;
 

--- a/interface/esb.h
+++ b/interface/esb.h
@@ -44,7 +44,9 @@ typedef struct esbPacket_s {
     uint8_t data[32];
   } __attribute__((packed));
   /* Written by the radio interrupt routine */
-  uint32_t rssi;
+  /* Since the value of the RSSI sample can only be between ~[0, 100] we down cast
+   * from uint32_t to uint8_t without lose of precision */
+  uint8_t rssi;
   unsigned int crc;
 } EsbPacket;
 

--- a/interface/syslink.h
+++ b/interface/syslink.h
@@ -45,6 +45,7 @@ bool syslinkSend(struct syslinkPacket *packet);
 #define SYSLINK_RADIO_CHANNEL  0x01
 #define SYSLINK_RADIO_DATARATE 0x02
 #define SYSLINK_RADIO_CONTWAVE 0x03
+#define SYSLINK_RADIO_RSSI     0x04
 
 
 #define SYSLINK_PM_SOURCE 0x10

--- a/src/esb.c
+++ b/src/esb.c
@@ -144,7 +144,7 @@ void esbInterruptHandler()
       }
 
       pk = &rxPackets[rxq_head];
-      pk->rssi = NRF_RADIO->RSSISAMPLE;
+      pk->rssi = (uint8_t) NRF_RADIO->RSSISAMPLE;
       pk->crc = NRF_RADIO->RXCRC;
 
       // If no more space available on RX queue, drop packet!

--- a/src/main.c
+++ b/src/main.c
@@ -140,6 +140,8 @@ void mainloop()
   bool esbReceived = false;
   bool slReceived;
   static int vbatSendTime;
+	static int radioRSSISendTime;
+	static uint32_t rssi;
 
   while(1)
   {
@@ -159,6 +161,8 @@ void mainloop()
     if ((esbReceived == false) && esbIsRxPacket())
     {
       EsbPacket* packet = esbGetRxPacket();
+			//Store RSSI here so that we can send it to STM later
+			rssi = packet->rssi;
       memcpy(esbRxPacket.data, packet->data, packet->size);
       esbRxPacket.size = packet->size;
       esbReceived = true;
@@ -285,6 +289,18 @@ void mainloop()
 
       syslinkSend(&slTxPacket);
     }
+		//Send an RSSI sample to the STM every 10ms(100Hz)
+		
+    if (systickGetTick() >= radioRSSISendTime + 10) {
+			radioRSSISendTime = systickGetTick();
+			slTxPacket.type = SYSLINK_RADIO_RSSI;
+			//This message contains only the RSSI measurement which consist
+			//of a single uint32_t
+			slTxPacket.length = sizeof(uint32_t);
+			memcpy(slTxPacket.data, &rssi, sizeof(uint32_t));
+
+			syslinkSend(&slTxPacket);
+		}
 #endif
 
     // Button event handling

--- a/src/main.c
+++ b/src/main.c
@@ -141,7 +141,7 @@ void mainloop()
   bool slReceived;
   static int vbatSendTime;
 	static int radioRSSISendTime;
-	static uint32_t rssi;
+	static uint8_t rssi;
 
   while(1)
   {
@@ -161,8 +161,8 @@ void mainloop()
     if ((esbReceived == false) && esbIsRxPacket())
     {
       EsbPacket* packet = esbGetRxPacket();
-			//Store RSSI here so that we can send it to STM later
-			rssi = packet->rssi;
+      //Store RSSI here so that we can send it to STM later
+      rssi = packet->rssi;
       memcpy(esbRxPacket.data, packet->data, packet->size);
       esbRxPacket.size = packet->size;
       esbReceived = true;
@@ -295,9 +295,9 @@ void mainloop()
 			radioRSSISendTime = systickGetTick();
 			slTxPacket.type = SYSLINK_RADIO_RSSI;
 			//This message contains only the RSSI measurement which consist
-			//of a single uint32_t
-			slTxPacket.length = sizeof(uint32_t);
-			memcpy(slTxPacket.data, &rssi, sizeof(uint32_t));
+			//of a single uint8_t
+			slTxPacket.length = sizeof(uint8_t);
+			memcpy(slTxPacket.data, &rssi, sizeof(uint8_t));
 
 			syslinkSend(&slTxPacket);
 		}


### PR DESCRIPTION
This commit adds support for sending RSSI measurements from the radio to
the main processor, STM32. This is done by storing the RSSI measurements
done on each received packet and then forwarding that RSSI sample to the
main processor at certain intervals. Currently the interval is set up to
perform at 100Hz.

This commit adds a new log constant used to send RSSI samples. A quick
updated of esb.h so that RSSI samples are not converted
between uint32_t -> int -> uint32_t.

Note: This commit is intended to work with the RSSI pull request to crazyflie-firmware