### PR TITLE
Add option to set device address of the Crazyflie via syslink interface.

### DIFF
--- a/interface/esb.h
+++ b/interface/esb.h
@@ -97,4 +97,7 @@ void esbSetTxPower(int power);
 /* Set of disable radio continuous wave */
 void esbSetContwave(bool enable);
 
+/* Set the address of the radio */
+void esbSetAddress(uint64_t address);
+
 #endif //__ESB_H__

--- a/interface/syslink.h
+++ b/interface/syslink.h
@@ -46,6 +46,7 @@ bool syslinkSend(struct syslinkPacket *packet);
 #define SYSLINK_RADIO_DATARATE 0x02
 #define SYSLINK_RADIO_CONTWAVE 0x03
 #define SYSLINK_RADIO_RSSI     0x04
+#define SYSLINK_RADIO_ADDRESS  0x05
 
 
 #define SYSLINK_PM_SOURCE 0x10

--- a/src/main.c
+++ b/src/main.c
@@ -174,7 +174,7 @@ void mainloop()
       EsbPacket* packet = &esbRxPacket;
       esbReceived = false;
 
-      if((packet->size == 4) && (packet->data[0]==0xff) && (packet->data[1]==0x03))
+      if((packet->size >= 4) && (packet->data[0]==0xff) && (packet->data[1]==0x03))
       {
         handleRadioCmd(packet);
       }
@@ -250,6 +250,19 @@ void mainloop()
             slTxPacket.type = SYSLINK_RADIO_CONTWAVE;
             slTxPacket.data[0] = slRxPacket.data[0];
             slTxPacket.length = 1;
+            syslinkSend(&slTxPacket);
+          }
+          break;
+        case SYSLINK_RADIO_ADDRESS:
+          if(slRxPacket.length == 5)
+          {
+            uint64_t address = 0;
+            memcpy(&address, &slRxPacket.data[0], 5);
+            esbSetAddress(address);
+
+            slTxPacket.type = SYSLINK_RADIO_ADDRESS;
+            memcpy(slTxPacket.data, slRxPacket.data, 5);
+            slTxPacket.length = 5;
             syslinkSend(&slTxPacket);
           }
           break;


### PR DESCRIPTION
This is part 2 of the effort of improving the multi-flie support by allowing custom device addresses.
Please see https://github.com/bitcraze/crazyflie-clients-python/pull/161 for the matching UI changes.