### PR TITLE
Fix compiler warning introduced in 76fe2ce

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ NRF_S110 ?= s110
 INCLUDES= -I Include -I Include/gcc -Iinterface
 
 #CONFIG = -DRSSI_ACK_PACKET
-BUILD_OPTION = -g3 -O0 -Wall -fsingle-precision-constant -ffast-math -std=gnu11
+BUILD_OPTION = -g3 -O0 -Wall -Werror -fsingle-precision-constant -ffast-math -std=gnu11
 PERSONAL_DEFINES ?=
 
 PROCESSOR = -mcpu=cortex-m0 -mthumb

--- a/src/pm.c
+++ b/src/pm.c
@@ -295,7 +295,7 @@ void pmSysBootloader(bool enable)
 const struct {
   void (*call)(bool enable);
   int delay;
-  int delayUp
+  int delayUp;
 } statesFunctions[] = {
   [pmAllOff] =       { .call = pmDummy ,      .delay = 2, .delayUp = 2},
   [pmSysOff] =       { .call = pmNrfPower,    .delay = 2, .delayUp = 200},


### PR DESCRIPTION
* Fix compiler warning caused by a missing semicolon.
* Enable error on warnings, so that future the CI finds such issues in
  the future.