### PR TITLE
pm: Increase delay before powering system

### DIFF
--- a/src/pm.c
+++ b/src/pm.c
@@ -298,7 +298,7 @@ const struct {
   int delayUp;
 } statesFunctions[] = {
   [pmAllOff] =       { .call = pmDummy ,      .delay = 2, .delayUp = 2},
-  [pmSysOff] =       { .call = pmNrfPower,    .delay = 2, .delayUp = 200},
+  [pmSysOff] =       { .call = pmNrfPower,    .delay = 2, .delayUp = 350},
   [pmSysPowered] =   { .call = pmPowerSystem, .delay = 2, .delayUp = 2},
   [pmSysBootSetup] = { .call = pmSysBoot,     .delay = 2, .delayUp = 2},
   [pmSysRunning] =   { .call = pmRunSystem,   .delay = 2, .delayUp = 2},


### PR DESCRIPTION
When updating the Lighthouse deck as part of the flashing procedure we
sometiems get stuck. The Lighthouse deck does not power on.

We suspect this is connected to the capacitors on the deck not getting
enough time to discharge in some conditions on some boards.

Some users tried out firmware with 250 ms and 300 ms delays and the 300
ms delay fixed the issue for them. We increase the delay here to 350 ms
to err on side of caution.

If boot-up times becomes an issue we could change this to only take
effect on soft-resets.

Fixes: #56
