### PR TITLE
Delay startup of STM32/decks with 1s to avoid GAP8 freeze

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -91,6 +91,13 @@ int main()
   systickInit();
   memoryInit();
 
+  // This is needed to avoid putting the GAP8 into an
+  // undefined state when powering off/on quickly or
+  // moving from bootloader to firmware. Without this
+  // the GAP8 might freeze and needs to be powered off
+  // for a while before recovering.
+  msDelay(1000);
+
   if (bleEnabled) {
     ble_init();
   } else {


### PR DESCRIPTION
When moving from bootloader to firmware on the nRF51 or when doing quick power off/on on the button, we've seen that the GAP8 end up in a state where it freezes and we need to power it off for a long while to get it to start again. It seems to be handling "quick" off/on cycles badly. This is fairly easy to reproduce in two cases:

* Put the Crazyflie in bootloader then press the power again to move from bootloader to firmware => GAP8 might not start (this is also true for _cload_)
* Press the power button repeatedly or just do a quick off/on => GAP8 will eventually not start

Note that the behavior seems to be a bit different on different boards, some are very easy to freeze others not.

Initially the time when the STM32/decks domain was powered off was about 350-400ms when moving from bootloader to firmware. Keeping the power off for longer seems to solve the issue with the GAP8 freeze, this is also true for quickly powering off/on the platform. After doing some quick testing it seems as if 1s is enough, but we should test some more boards.

At this point we have information about the 1-wire memories and it would be possible to only have this delay when the AI-deck is attached, but this would create a special case that might be confusing down the line if there's any issues.