### PR TITLE
Syslink will now only enable send after a packet has been received.

### DIFF
--- a/interface/syslink.h
+++ b/interface/syslink.h
@@ -38,11 +38,31 @@ struct syslinkPacket {
   char data[SYSLINK_MTU];
 };
 
+/**
+ * Receive syslink packet.
+ *
+ * @param packet  Syslink packet to receive data.
+ */
 bool syslinkReceive(struct syslinkPacket *packet);
 
+/**
+ * Send syslink packet.
+ * Will only send if link is first activated by a packet beeing received.
+ *
+ * @param packet  Syslink packet containing data to send.
+ */
 bool syslinkSend(struct syslinkPacket *packet);
+
+/**
+ * Reset syslink state machine.
+ */
 void syslinkReset();
 
+/**
+ * Deactivate syslink. Meaning no packets will be sent
+ * until a packet first has been received.
+ */
+void syslinkDeactivateUntilPacketReceived();
 
 // Defined packet types
 #define SYSLINK_RADIO_RAW           0x00


### PR DESCRIPTION
The nrf is sending battery information continuously after a delay after startup. This mechanism was broken causing it to never send the battery information. The logic has now been rewritten so that the syslink packets going out will fist be allowed to do so after a packet has been received which happes as soon as the STM sets that radio address.

Some minor refactoring as well splitting the big mainLoop function into sub-functions.

Fixes #1043