### PR TITLE
Add debug probe for radio setup

### DIFF
--- a/interface/syslink.h
+++ b/interface/syslink.h
@@ -95,4 +95,6 @@ void syslinkDeactivateUntilPacketReceived();
 
 #define SYSLINK_SYS_NRF_VERSION 0x30
 
+#define SYSLINK_DEBUG_PROBE 0xF0
+
 #endif

--- a/interface/uart.h
+++ b/interface/uart.h
@@ -40,4 +40,6 @@ bool uartIsDataReceived();
 
 char uartGetc();
 
+int uartDropped();
+
 #endif //__UART_H__

--- a/src/main.c
+++ b/src/main.c
@@ -90,6 +90,10 @@ static void handleRadioCmd(struct esbPacket_s * packet);
 static void handleBootloaderCmd(struct esbPacket_s *packet);
 static void disableBle();
 
+static bool debugProbeReceivedChan = false;
+static bool debugProbeReceivedAddress = false;
+static bool debugProbeReceivedRate = false;
+
 int main()
 {
   // Stop early if the platform is not supported
@@ -305,6 +309,8 @@ static void handleSyslinkEvents(bool slReceived)
           slTxPacket.data[0] = slRxPacket.data[0];
           slTxPacket.length = 1;
           syslinkSend(&slTxPacket);
+
+          debugProbeReceivedChan = true;
         }
         break;
       case SYSLINK_RADIO_DATARATE:
@@ -316,6 +322,8 @@ static void handleSyslinkEvents(bool slReceived)
           slTxPacket.data[0] = slRxPacket.data[0];
           slTxPacket.length = 1;
           syslinkSend(&slTxPacket);
+
+          debugProbeReceivedRate = true;
         }
         break;
       case SYSLINK_RADIO_CONTWAVE:
@@ -339,6 +347,8 @@ static void handleSyslinkEvents(bool slReceived)
           memcpy(slTxPacket.data, slRxPacket.data, 5);
           slTxPacket.length = 5;
           syslinkSend(&slTxPacket);
+
+          debugProbeReceivedAddress = true;
         }
         break;
       case SYSLINK_RADIO_POWER:
@@ -395,6 +405,18 @@ static void handleSyslinkEvents(bool slReceived)
         break;
       case SYSLINK_PM_LED_OFF:
         LED_OFF();
+        break;
+      case SYSLINK_DEBUG_PROBE:
+      {
+        slTxPacket.type = SYSLINK_DEBUG_PROBE;
+        slTxPacket.data[0] = debugProbeReceivedAddress;
+        slTxPacket.data[1] = debugProbeReceivedChan;
+        slTxPacket.data[2] = debugProbeReceivedRate;
+        slTxPacket.data[3] = (uint8_t)uartDropped();
+
+        slTxPacket.length = 4;
+        syslinkSend(&slTxPacket);
+      }
         break;
     }
   }

--- a/src/uart.c
+++ b/src/uart.c
@@ -177,3 +177,7 @@ char uartGetc()
 
   return c;
 }
+
+int uartDropped() {
+  return dropped;
+}


### PR DESCRIPTION
Add code to collect debug data for the bitcraze/crazyflie-firmware#998
Added new syslink message to send the data to the STM on request.

We do not know what is causing this problem and this is a first step to collect data. This code should probably be removed when the problem is solved. 
