### PR TITLE
Optimized build from none (-O0) to size (-Os)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ NRF_S110 ?= s110
 INCLUDES= -I Include -I Include/gcc -Iinterface
 
 #CONFIG = -DRSSI_ACK_PACKET
-BUILD_OPTION = -g3 -O0 -Wall -Werror -fsingle-precision-constant -ffast-math -std=gnu11
+BUILD_OPTION = -g3 -Os -Wall -Werror -fsingle-precision-constant -ffast-math -std=gnu11
 PERSONAL_DEFINES ?=
 
 PROCESSOR = -mcpu=cortex-m0 -mthumb
@@ -40,7 +40,7 @@ PROGRAM=$(PLATFORM)_nrf
 
 CFLAGS+=$(PROCESSOR) $(NRF) $(PERSONAL_DEFINES) $(INCLUDES) $(CONFIG) $(BUILD_OPTION)
 ASFLAGS=$(PROCESSOR)
-LDFLAGS=$(PROCESSOR) -O0 --specs=nano.specs -Wl,-Map=$(PROGRAM).map# -Wl,--gc-sections
+LDFLAGS=$(PROCESSOR) --specs=nano.specs -Wl,-Map=$(PROGRAM).map# -Wl,--gc-sections
 ifdef SEMIHOSTING
 LDFLAGS+= --specs=rdimon.specs -lc -lrdimon
 CFLAGS+= -DSEMIHOSTING

--- a/src/esb.c
+++ b/src/esb.c
@@ -50,23 +50,23 @@ static uint64_t address = 0xE7E7E7E7E7ULL;
 
 static enum {doTx, doRx} rs;      //Radio state
 
-static EsbPacket rxPackets[RXQ_LEN];
-static int rxq_head = 0;
-static int rxq_tail = 0;
+static volatile EsbPacket rxPackets[RXQ_LEN];
+static volatile int rxq_head = 0;
+static volatile int rxq_tail = 0;
 
-static EsbPacket txPackets[TXQ_LEN];
-static int txq_head = 0;
-static int txq_tail = 0;
+static volatile EsbPacket txPackets[TXQ_LEN];
+static volatile int txq_head = 0;
+static volatile int txq_tail = 0;
 
 // 1bit packet counters
-static int curr_down = 1;
-static int curr_up = 1;
+static volatile int curr_down = 1;
+static volatile int curr_up = 1;
 
-static bool has_safelink;
+static volatile bool has_safelink;
 
-static EsbPacket ackPacket;     // Empty ack packet
-static EsbPacket servicePacket; // Packet sent to answer a low level request
-static EsbPacket p2pPacket;     // Packet to send to other crazyflie in broadcast
+static volatile EsbPacket ackPacket;     // Empty ack packet
+static volatile EsbPacket servicePacket; // Packet sent to answer a low level request
+static volatile EsbPacket p2pPacket;     // Packet to send to other crazyflie in broadcast
 /* helper functions */
 
 static uint32_t swap_bits(uint32_t inp)

--- a/src/esb.c
+++ b/src/esb.c
@@ -50,11 +50,11 @@ static uint64_t address = 0xE7E7E7E7E7ULL;
 
 static enum {doTx, doRx} rs;      //Radio state
 
-static volatile EsbPacket rxPackets[RXQ_LEN];
+static EsbPacket rxPackets[RXQ_LEN];
 static volatile int rxq_head = 0;
 static volatile int rxq_tail = 0;
 
-static volatile EsbPacket txPackets[TXQ_LEN];
+static EsbPacket txPackets[TXQ_LEN];
 static volatile int txq_head = 0;
 static volatile int txq_tail = 0;
 
@@ -64,9 +64,9 @@ static volatile int curr_up = 1;
 
 static volatile bool has_safelink;
 
-static volatile EsbPacket ackPacket;     // Empty ack packet
-static volatile EsbPacket servicePacket; // Packet sent to answer a low level request
-static volatile EsbPacket p2pPacket;     // Packet to send to other crazyflie in broadcast
+static EsbPacket ackPacket;     // Empty ack packet
+static EsbPacket servicePacket; // Packet sent to answer a low level request
+static EsbPacket p2pPacket;     // Packet to send to other crazyflie in broadcast
 /* helper functions */
 
 static uint32_t swap_bits(uint32_t inp)

--- a/src/ow/owlnk.c
+++ b/src/ow/owlnk.c
@@ -49,7 +49,7 @@
 #define TICK_PER_US 16
 
 //local variables
-static bool running = false;
+static volatile bool running = false;
 static int sample = 0;
 
 // exportable link-level functions

--- a/src/systick.c
+++ b/src/systick.c
@@ -25,7 +25,7 @@
  */
 #include <nrf.h>
 
-static unsigned int tick = 0;
+static volatile unsigned int tick = 0;
 
 //void RTC1_IRQHandler()
 void TIMER2_IRQHandler()

--- a/src/uart.c
+++ b/src/uart.c
@@ -35,15 +35,15 @@ static bool isInit = false;
 
 #define Q_LENGTH 128
 
-static char rxq[Q_LENGTH];
-static int head = 0;
-static int tail = 0;
+static volatile char rxq[Q_LENGTH];
+static volatile int head = 0;
+static volatile int tail = 0;
 
-static int dropped = 0;
-static char dummy;
+static volatile int dropped = 0;
+static volatile char dummy;
 
-static uint8_t uartError = 0;
-static uint8_t uartErrorCount = 0;
+static volatile uint8_t uartError = 0;
+static volatile uint8_t uartErrorCount = 0;
 
 void UART0_IRQHandler()
 {


### PR DESCRIPTION
The nRF51822 code has not been optimized by the compiler. During investigation of the syslink this was found and optimizing it improves the syslink speed and less uart-RTS delays. In overall it should improve performance.

When first enabling optimization the nRF locked up. This turned out to be the running variable in OwLnk.c not being volatile and altered in TIMER1_IRQHandler. This solved the lockup but to be sure I made all variables used in interrupt service routines volatile.