### PR TITLE
Revert optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ NRF_S110 ?= s110
 INCLUDES= -I Include -I Include/gcc -Iinterface
 
 #CONFIG = -DRSSI_ACK_PACKET
-BUILD_OPTION = -g3 -Os -Wall -Werror -fsingle-precision-constant -ffast-math -std=gnu11
+BUILD_OPTION = -g3 -O0 -Wall -Werror -fsingle-precision-constant -ffast-math -std=gnu11
 PERSONAL_DEFINES ?=
 
 PROCESSOR = -mcpu=cortex-m0 -mthumb

--- a/src/esb.c
+++ b/src/esb.c
@@ -48,7 +48,7 @@ static int txpower = RADIO_TXPOWER_TXPOWER_0dBm;
 static bool contwave = false;
 static uint64_t address = 0xE7E7E7E7E7ULL;
 
-static enum {doTx, doRx} rs;      //Radio state
+static volatile enum {doTx, doRx} rs;      //Radio state
 
 static EsbPacket rxPackets[RXQ_LEN];
 static volatile int rxq_head = 0;
@@ -97,7 +97,7 @@ static uint32_t bytewise_bitswap(uint32_t inp)
 // Handles the queue
 static void setupTx(bool retry, bool empty)
 {
-  static EsbPacket * lastSentPacket;
+  static volatile EsbPacket * lastSentPacket;
 
   if (!empty && retry) {
     NRF_RADIO->PACKETPTR = (uint32_t)lastSentPacket;


### PR DESCRIPTION
There seems to be a problem when running with the optimized compile. One of the load tests in the stab lab (`test_bandwidth_big_packets()`) indicates that we loose some packets.
We have not figured out what the reason is, and at this point we prioritize getting a stable release out. This PR reverts the compiler optimization.

Related to #72