### PR TITLE
Read build targets from file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,12 +8,16 @@ on:
     branches: [ master ]
 
 jobs:
+  read_targets_from_file:
+    uses: ./.github/workflows/read_build_targets.yml
+
   build:
+    needs: read_targets_from_file
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        platform: [cf2, tag, bolt]
+        ${{fromJson(needs.read_targets_from_file.outputs.platforms)}}
 
     env:
       PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/read_build_targets.yml
+++ b/.github/workflows/read_build_targets.yml
@@ -1,0 +1,39 @@
+# This work flow checks out the repo and reads the list of release targets from
+# the build_targetst.json file.
+
+# The list of targets is available in needs.read_targets_from_file.outputs.platforms as a json dictionary, use it
+# in matrix like this: ${{fromJson(needs.read_targets_from_file.outputs.platforms)}}
+
+name: Read build targets
+
+on:
+  workflow_call:
+    outputs:
+      platforms:
+        description: "'platform' is set to the list of targets"
+        value: ${{ jobs.read_targets_from_file.outputs.platforms }}
+
+permissions:
+  contents: read
+
+jobs:
+  read_targets_from_file:
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.read-build-target-from-file.outputs.platforms }}
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+
+    - id: read-build-target-from-file
+      run: |
+        content=`cat ./build_targets.json`
+        # the following lines are required for multi line json
+        content="${content//'%'/'%25'}"
+        content="${content//$'\n'/'%0A'}"
+        content="${content//$'\r'/'%0D'}"
+        # end of handling for multi line json
+        echo "::set-output name=platforms::$content"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  read_targets_from_file:
+    uses: ./.github/workflows/read_build_targets.yml
+
   release:
     name: Create Release on Github
+    needs: read_targets_from_file
     runs-on: ubuntu-latest
     steps:
     - name: Create Release
@@ -26,7 +30,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: release_url
-        path: release_url.txt       
+        path: release_url.txt
 
   upload:
     name: Upload Binaries to release
@@ -35,8 +39,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platforms: [cf2, tag, bolt]
-  
+        ${{fromJson(needs.read_targets_from_file.outputs.platforms)}}
+
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -44,7 +48,7 @@ jobs:
         submodules: true
 
     - name: Build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "./tools/build/build PLATFORM=${{ matrix.platforms }} UNIT_TEST_STYLE=min"
+      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "./tools/build/build PLATFORM=${{ matrix.platform }} UNIT_TEST_STYLE=min"
 
     - name: Load Release URL File from release job
       uses: actions/download-artifact@v1
@@ -56,19 +60,19 @@ jobs:
       run: |
         value=`cat release_url/release_url.txt`
         echo ::set-output name=upload_url::$value
-        
-    - name: Get the version 
-      id: get_release_version 
-      env: 
+
+    - name: Get the version
+      id: get_release_version
+      env:
         GITHUB_REF : ${{ github.ref }}
       run: echo ::set-output name=release_version::${GITHUB_REF/refs\/tags\//}
-      
-    - name: Upload ${{ matrix.platforms }} bin
+
+    - name: Upload ${{ matrix.platform }} bin
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ${{ matrix.platforms }}_nrf.bin
-        asset_name: ${{ matrix.platforms }}_nrf-${{ steps.get_release_version.outputs.release_version }}.bin
+        asset_path: ${{ matrix.platform }}_nrf.bin
+        asset_name: ${{ matrix.platform }}_nrf-${{ steps.get_release_version.outputs.release_version }}.bin
         asset_content_type: application/octet-stream

--- a/build_targets.json
+++ b/build_targets.json
@@ -1,0 +1,7 @@
+{
+    "platform" : [
+      "cf2",
+      "bolt",
+      "tag"
+    ]
+  }

--- a/module.json
+++ b/module.json
@@ -2,25 +2,5 @@
   "version": "1.0",
   "environmentReq": [
     "arm-none-eabi"
-  ],
-  "artifacts": {
-    "file": [
-      {
-        "source": "*.bin",
-        "insertTag": true,
-        "destination": "currDir"
-      }
-    ]
-  },
-  "targets": {
-    "cf2": [
-      "PLATFORM=cf2"
-    ],
-    "tag": [
-      "PLATFORM=tag"
-    ],
-    "bolt": [
-      "PLATFORM=bolt"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
This PR introduces a new file (build_targets.json) with a list of platforms to build. This file is used both in CI and release builds.