### PR TITLE
Changed power bit flags sent through syslink

### DIFF
--- a/interface/pm.h
+++ b/interface/pm.h
@@ -31,9 +31,8 @@ typedef enum {chgOff=0, chgCharging=1, chgCharged=2} ChgState;
 
 void pmInit();
 
-bool pmUSBPower(void);
-
-bool pmIsCharging(void);
+/* Return power flags that indicate if we're plugged in to USB, currently charging and if we can charge. */
+uint8_t getPowerStatusFlags();
 
 float pmGetVBAT(void);
 

--- a/src/main.c
+++ b/src/main.c
@@ -432,15 +432,13 @@ static void sendDataToStmOverSyslink()
   if (systickGetTick() >= vbatSendTime + SYSLINK_SEND_PERIOD_MS)
   {
     float fdata;
-    uint8_t flags = 0;
 
     vbatSendTime = systickGetTick();
     slTxPacket.type = SYSLINK_PM_BATTERY_STATE;
     slTxPacket.length = 9;
 
-    flags |= (pmIsCharging() == true) ? 0x01:0;
-    flags |= (pmUSBPower()   == true) ? 0x02:0;
-
+    // Set flags that if we're plugged in to USB, currently charging and if we can charge.
+    uint8_t flags = getPowerStatusFlags();
     slTxPacket.data[0] = flags;
 
     fdata = pmGetVBAT();


### PR DESCRIPTION
Changed the flags that are sent through syslink from nrf to stm to make more sense. Previously, the value `pGood` was included, which had different physical meanings depending on platform (bolt, CF2).
I also added some explanation in the code, as comments.