### PR TITLE
Fix for Crazyswarm2 problem

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -639,10 +639,10 @@ static void handleBootloaderCmd(struct esbPacket_s *packet)
 static void disableBle() {
 #ifdef BLE
   if (bleEnabled) {
-      sd_softdevice_disable();
-      esbInit();
+    sd_softdevice_disable();
+    bleEnabled = 0;
+    esbInit();
   }
 #endif
-
-    bleEnabled = 0;
+  bleEnabled = 0;
 }


### PR DESCRIPTION
See https://github.com/IMRCLab/crazyswarm2/issues/327 for background

After the changes in #91 there is a difference when BLE is disabled (after the first CR packet is received) as `esbInit()` is called before `bleEnabled` is set to 0. This PR fixes this difference. 