### PR TITLE
Add radiotest functionality to FW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@
 PLATFORM ?= cf2
 -include platform/platform_$(PLATFORM).mk
 
+ifeq ($(RADIOTEST),1)
 BLE      ?= 0    # BLE mode activated or not. If disabled, CRTP mode is active
+else
+BLE	  ?= 1    # BLE mode activated or not. If disabled, CRTP mode is active
+endif
 
 PROGRAM = $(PLATFORM)_nrf
 PROJECT_NAME     := crazyflie2_nrf_firmware

--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,10 @@ ifeq ($(strip $(RADIOTEST)), 1)
 CFLAGS += -DRADIOTEST=1
 endif
 
+ifeq ($(strip $(EXT_ANTENNA)), 1)
+CFLAGS += -DUSE_EXT_ANTENNA=1
+endif
+
 # C++ flags common to all targets
 CXXFLAGS += \
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,15 @@ else
 BLE	  ?= 1    # BLE mode activated or not. If disabled, CRTP mode is active
 endif
 
+PYTHON            ?= python3
+
+# Cload is handled in a special way on windows in WSL to use the Windows python interpreter
+ifdef WSL_DISTRO_NAME
+CLOAD_SCRIPT      ?= python.exe -m cfloader
+else
+CLOAD_SCRIPT      ?= $(PYTHON) -m cfloader
+endif
+
 PROGRAM = $(PLATFORM)_nrf
 PROJECT_NAME     := crazyflie2_nrf_firmware
 TARGETS          := $(PROGRAM)

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@
 PLATFORM ?= cf2
 -include platform/platform_$(PLATFORM).mk
 
-ifeq ($(RADIOTEST),1)
+ifeq ($(RECIEVE_RADIOTEST),1)
 BLE      ?= 0    # BLE mode activated or not. If disabled, CRTP mode is active
 else
-BLE	  ?= 1    # BLE mode activated or not. If disabled, CRTP mode is active
+BLE	  ?= 1
 endif
 
 PYTHON            ?= python3
@@ -239,6 +239,10 @@ CFLAGS += -DUSE_APP_CONFIG
 
 ifeq ($(strip $(BLE)), 1)
 CFLAGS += -DBLE=1
+endif
+
+ifeq ($(strip $(RADIOTEST)), 1)
+CFLAGS += -DRADIOTEST=1
 endif
 
 # C++ flags common to all targets

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PLATFORM ?= cf2
 -include platform/platform_$(PLATFORM).mk
 
-BLE      ?= 1    # BLE mode activated or not. If disabled, CRTP mode is active
+BLE      ?= 0    # BLE mode activated or not. If disabled, CRTP mode is active
 
 PROGRAM = $(PLATFORM)_nrf
 PROJECT_NAME     := crazyflie2_nrf_firmware

--- a/src/esb.c
+++ b/src/esb.c
@@ -316,17 +316,7 @@ void esbInit()
 
   NRF_RADIO->TXPOWER = (txpower << RADIO_TXPOWER_TXPOWER_Pos);
 
-  switch (datarate) {
-  case esbDatarate250K:
-      NRF_RADIO->MODE = (RADIO_MODE_MODE_Nrf_250Kbit << RADIO_MODE_MODE_Pos);
-      break;
-  case esbDatarate1M:
-      NRF_RADIO->MODE = (RADIO_MODE_MODE_Nrf_1Mbit << RADIO_MODE_MODE_Pos);
-      break;
-  case esbDatarate2M:
-      NRF_RADIO->MODE = (RADIO_MODE_MODE_Nrf_2Mbit << RADIO_MODE_MODE_Pos);
-      break;
-  }
+  NRF_RADIO->MODE = (RADIO_MODE_MODE_Ble_1Mbit << RADIO_MODE_MODE_Pos);
 
   NRF_RADIO->FREQUENCY = channel;
 
@@ -482,9 +472,7 @@ void esbSendP2PPacket(uint8_t port, char *data, uint8_t length)
 
 void esbSetDatarate(EsbDatarate dr)
 {
-  datarate = dr;
-
-  esbReset();
+  //NOP
 }
 
 

--- a/src/esb.c
+++ b/src/esb.c
@@ -44,14 +44,15 @@
 
 extern int bleEnabled;
 
-#define RXQ_LEN 8
-#define TXQ_LEN 8
-
 static bool isInit = true;
 
 static int channel = 80;
 static int datarate = esbDatarate2M;
+#if defined(RADIOTEST) && (RADIOTEST == 1)
 static int txpower = RADIO_TXPOWER_TXPOWER_Neg16dBm;
+#else
+static int txpower = RADIO_TXPOWER_TXPOWER_0dBm;
+#endif
 static bool contwave = false;
 static uint64_t address = 0xE7E7E7E7E7ULL;
 
@@ -152,38 +153,36 @@ static void setupTx(bool retry, bool empty)
       lastSentPacket = &ackPacket;
     }
   } else { // Send back empty ack (for P2P)
+#if defined(RADIOTEST) && (RADIOTEST == 1)
     ackPacket.size = 32;
-    NRF_RADIO->PACKETPTR = (uint32_t)&ackPacket;
     NRF_RADIO->PCNF1 |= RADIO_PCNF1_WHITEEN_Msk;
+#else
+    ackPacket.size = 0;
+    NRF_RADIO->PACKETPTR = (uint32_t)&ackPacket;
+#endif
   }
 
   NRF_RADIO->TXADDRESS = 0x00UL;
 
   //After being disabled the radio will automatically send the ACK
-  if (rs == doTx) {
-    // NRF_RADIO->TASKS_START = 1UL;
-    NRF_RADIO->SHORTS &= ~RADIO_SHORTS_DISABLED_RXEN_Msk;
-    NRF_RADIO->SHORTS |= RADIO_SHORTS_DISABLED_TXEN_Msk;
-    NRF_RADIO->TASKS_DISABLE = 1UL;
-  } else {
-    NRF_RADIO->SHORTS &= ~RADIO_SHORTS_DISABLED_RXEN_Msk;
-    NRF_RADIO->SHORTS |= RADIO_SHORTS_DISABLED_TXEN_Msk;
-    NRF_RADIO->TASKS_DISABLE = 1UL;
-  }
+
+  NRF_RADIO->SHORTS &= ~RADIO_SHORTS_DISABLED_RXEN_Msk;
+  NRF_RADIO->SHORTS |= RADIO_SHORTS_DISABLED_TXEN_Msk;
   
   rs = doTx;
-  
+  NRF_RADIO->TASKS_DISABLE = 1UL;
 }
 
-// static void setupRx()
-// {
-//   NRF_RADIO->PACKETPTR = (uint32_t)&rxPackets[rxq_head];
-
-//   NRF_RADIO->SHORTS &= ~RADIO_SHORTS_DISABLED_TXEN_Msk;
-//   NRF_RADIO->SHORTS |= RADIO_SHORTS_DISABLED_RXEN_Msk;
-//   rs = doRx;
-//   NRF_RADIO->TASKS_DISABLE = 1UL;
-// }
+#if !defined(RADIOTEST) || (RADIOTEST == 0)
+static void setupRx()
+{
+  NRF_RADIO->PACKETPTR = (uint32_t)&rxPackets[rxq_head];
+  NRF_RADIO->SHORTS &= ~RADIO_SHORTS_DISABLED_TXEN_Msk;
+  NRF_RADIO->SHORTS |= RADIO_SHORTS_DISABLED_RXEN_Msk;
+  rs = doRx;
+  NRF_RADIO->TASKS_DISABLE = 1UL;
+}
+#endif
 
 void RADIO_IRQHandler()
 {
@@ -279,7 +278,12 @@ void esbInterruptHandler()
       break;
     case doTx:
       //Setup RX for next packet
+#if defined(RADIOTEST) && (RADIOTEST == 1)
       setupTx(false, true);
+#else 
+      setupRx();
+#endif
+      
       break;
     }
   }
@@ -375,12 +379,14 @@ void esbInit()
   NRF_RADIO->SHORTS |= RADIO_SHORTS_DISABLED_TXEN_Msk;
   NRF_RADIO->SHORTS |= RADIO_SHORTS_DISABLED_RSSISTOP_Enabled;
 
-  // Set RX buffer and start RX
-  // rs = doRx;
-	// NRF_RADIO->PACKETPTR = (uint32_t)&rxPackets[rxq_head];
-  // NRF_RADIO->TASKS_RXEN = 1U;
-
+#if defined(RADIOTEST) && (RADIOTEST == 1)
   setupTx(false, true);
+#else
+  // Set RX buffer and start RX
+  rs = doRx;
+  NRF_RADIO->PACKETPTR = (uint32_t)&rxPackets[rxq_head];
+  NRF_RADIO->TASKS_RXEN = 1U;
+#endif
 
   isInit = true;
 }
@@ -482,7 +488,10 @@ void esbSendP2PPacket(uint8_t port, char *data, uint8_t length)
 
 void esbSetDatarate(EsbDatarate dr)
 {
-  //NOP
+#if !defined(RADIOTEST) || (RADIOTEST == 0)
+  datarate = dr;
+  esbReset();
+#endif
 }
 
 

--- a/src/esb.c
+++ b/src/esb.c
@@ -44,8 +44,8 @@
 
 extern int bleEnabled;
 
-#define RXQ_LEN 16
-#define TXQ_LEN 16
+#define RXQ_LEN 8
+#define TXQ_LEN 8
 
 static bool isInit = true;
 

--- a/src/esb.c
+++ b/src/esb.c
@@ -316,7 +316,17 @@ void esbInit()
 
   NRF_RADIO->TXPOWER = (txpower << RADIO_TXPOWER_TXPOWER_Pos);
 
-  NRF_RADIO->MODE = (RADIO_MODE_MODE_Ble_1Mbit << RADIO_MODE_MODE_Pos);
+  switch (datarate) {
+  case esbDatarate250K:
+      NRF_RADIO->MODE = (RADIO_MODE_MODE_Nrf_250Kbit << RADIO_MODE_MODE_Pos);
+      break;
+  case esbDatarate1M:
+      NRF_RADIO->MODE = (RADIO_MODE_MODE_Nrf_1Mbit << RADIO_MODE_MODE_Pos);
+      break;
+  case esbDatarate2M:
+      NRF_RADIO->MODE = (RADIO_MODE_MODE_Nrf_2Mbit << RADIO_MODE_MODE_Pos);
+      break;
+  }
 
   NRF_RADIO->FREQUENCY = channel;
 

--- a/src/esb.c
+++ b/src/esb.c
@@ -44,16 +44,12 @@
 
 extern int bleEnabled;
 
-#ifndef TEST_CHANNEL
-#error Please provide a test channel with: make PERSONAL_DEFINES="-DTEST_CHANNEL=80"
-#endif
-
 #define RXQ_LEN 16
 #define TXQ_LEN 16
 
 static bool isInit = true;
 
-static int channel = TEST_CHANNEL;
+static int channel = 80;
 static int datarate = esbDatarate2M;
 static int txpower = RADIO_TXPOWER_TXPOWER_Neg12dBm;
 static bool contwave = false;
@@ -517,12 +513,11 @@ void esbSetContwave(bool enable)
 
 void esbSetChannel(unsigned int ch)
 {
-  // if (channel < 126) {
-	//   channel = ch;
-	// }
+  if (channel < 126) {
+	  channel = ch;
+	}
 
-  // esbReset();
-  // NOP
+  esbReset();
 }
 
 void esbSetTxPower(int power)

--- a/src/esb.c
+++ b/src/esb.c
@@ -51,7 +51,7 @@ static bool isInit = true;
 
 static int channel = 80;
 static int datarate = esbDatarate2M;
-static int txpower = RADIO_TXPOWER_TXPOWER_Neg12dBm;
+static int txpower = RADIO_TXPOWER_TXPOWER_Neg16dBm;
 static bool contwave = false;
 static uint64_t address = 0xE7E7E7E7E7ULL;
 

--- a/src/pm.c
+++ b/src/pm.c
@@ -289,7 +289,7 @@ static void pmRunSystem(bool enable)
       nrf_gpio_cfg_output(RADIO_PA_RX_EN);
       nrf_gpio_cfg_output(RADIO_PA_MODE);
       nrf_gpio_cfg_output(RADIO_PA_ANT_SW);
-    #ifdef USE_EXT_ANTENNA
+    #if defined(USE_EXT_ANTENNA) && (USE_EXT_ANTENNA == 1)
       // Select u.FL antenna
       nrf_gpio_pin_clear(RADIO_PA_ANT_SW);
     #else


### PR DESCRIPTION
Add functionality to nrf FW to be able to enable radiotest mode using compile flags.

Three different FWs can be built. Normal radiotest with chip antenna, radiotest using external antenna and 
recieve radiotest. 

