### PR TITLE
Add last 3 bytes of the MAC address to the ble name

### DIFF
--- a/src/ble/ble.c
+++ b/src/ble/ble.c
@@ -102,7 +102,8 @@
 #define CENTRAL_LINK_COUNT              0                                           /**< Number of central links used by the application. When changing this number remember to adjust the RAM settings*/
 #define PERIPHERAL_LINK_COUNT           1                                           /**< Number of peripheral links used by the application. When changing this number remember to adjust the RAM settings*/
 
-#define DEVICE_NAME                     "Crazyflie"                                /**< Name of device. Will be included in the advertising data. */
+#define DEVICE_NAME                     "Crazyflie-xxxxxx"                          /**< Name of device. Will be included in the advertising data, will contain the last 3 bytes of the device address */
+static char device_name[32] = DEVICE_NAME;
 #define MANUFACTURER_NAME               "Bitcraze AB"                               /**< Manufacturer. Will be passed to Device Information Service. */
 #define APP_ADV_INTERVAL                300                                         /**< The advertising interval (in units of 0.625 ms. This value corresponds to 187.5 ms). */
 
@@ -302,9 +303,10 @@ static void gap_params_init(void)
 
     BLE_GAP_CONN_SEC_MODE_SET_OPEN(&sec_mode);
 
+    sprintf(device_name, "Crazyflie-%06X", (unsigned int)NRF_FICR->DEVICEADDR[0] & 0x00FFFFFF);
     err_code = sd_ble_gap_device_name_set(&sec_mode,
-                                          (const uint8_t *)DEVICE_NAME,
-                                          strlen(DEVICE_NAME));
+                                          (const uint8_t *)device_name,
+                                          strlen(device_name));
     APP_ERROR_CHECK(err_code);
 
     // YOUR_JOB: Use an appearance value matching the application's use case.


### PR DESCRIPTION
When using BLE-only client, it is needed to differenciate multiple Crazyflies.

This PR adds the last 3 bytes of the random nRF51 address to the BLE device name. This allows client to easily differenciate multiple Crazyflies.