### PR TITLE
Delay STM/decks boot by 5 seconds if AI-deck is attached

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ SRC_FILES += $(PROJ_DIR)/platform_$(PLATFORM).c
 SRC_FILES += $(PROJ_DIR)/debug.c
 SRC_FILES += $(PROJ_DIR)/systick.c
 SRC_FILES += $(PROJ_DIR)/shutdown.c
+SRC_FILES += $(PROJ_DIR)/crc32_calc.c
 
 # Include folders common to all targets
 INC_FOLDERS += $(SDK_ROOT)/components/softdevice/s130/headers

--- a/interface/crc32_calc.h
+++ b/interface/crc32_calc.h
@@ -1,0 +1,48 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie 2.x NRF Firmware
+ *
+ * Copyright (C) 2025 Bitcraze AB
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ *
+ *
+ * crc32_calc.h - defines the interface for CRC32 checksum
+ *                calculation. Contains function declarations for
+ *                computing CRC32 checksums on data buffers.
+ *
+ */
+
+#ifndef CRC32_CALC_H
+#define CRC32_CALC_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/**
+ * @brief Computes a 32-bit CRC using the polynomial 0xEDB88320.
+ *        The remainder is XORed with 0xFFFFFFFF at the end.
+ *
+ * @param buffer Pointer to the data buffer
+ * @param size   Number of bytes in the buffer
+ * @return       32-bit CRC of the data
+ */
+uint32_t crc32CalculateBuffer(const void* buffer, size_t size);
+
+#endif /* CRC32_CALC_H */

--- a/interface/memory.h
+++ b/interface/memory.h
@@ -32,6 +32,8 @@ void memoryInit();
 
 bool memorySyslink(struct syslinkPacket *pk);
 
+bool memoryHasBcAiDeck(void);
+
 struct memoryCommand_s {
   uint8_t nmem;
   union {

--- a/interface/memory.h
+++ b/interface/memory.h
@@ -32,7 +32,7 @@ void memoryInit();
 
 bool memorySyslink(struct syslinkPacket *pk);
 
-bool memoryHasBcAiDeck(void);
+bool memoryHasDeck(uint8_t vid, uint8_t pid, const char *boardName);
 
 struct memoryCommand_s {
   uint8_t nmem;

--- a/src/crc32_calc.c
+++ b/src/crc32_calc.c
@@ -1,0 +1,76 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie 2.x NRF Firmware
+ *
+ * Copyright (C) 2025 Bitcraze AB
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ *
+ *
+ * crc32_calc.c - implements CRC32 checksum calculation
+ *                functionality for verifying data integrity in
+ *                memory and communication. Provides straightforward
+ *                CRC32 computation using bitwise operations.
+ *
+ */
+
+#include "crc32_calc.h"
+#include <stddef.h>
+
+#define POLYNOMIAL        0xEDB88320u
+#define INITIAL_REMAINDER 0xFFFFFFFFu
+#define FINAL_XOR_VALUE   0xFFFFFFFFu
+
+static uint32_t crc32ByBit(const uint8_t* message, uint32_t length)
+{
+    uint32_t remainder = INITIAL_REMAINDER;
+
+    for (uint32_t i = 0; i < length; i++)
+    {
+        remainder ^= (uint32_t)message[i];
+        // Process 8 bits
+        for (int b = 0; b < 8; b++)
+        {
+            if (remainder & 1)
+            {
+                remainder = (remainder >> 1) ^ POLYNOMIAL;
+            }
+            else
+            {
+                remainder >>= 1;
+            }
+        }
+    }
+
+    remainder ^= FINAL_XOR_VALUE;
+    return remainder;
+}
+
+/**
+ * @brief Computes a 32-bit CRC using the polynomial 0xEDB88320.
+ *        The remainder is XORed with 0xFFFFFFFF at the end.
+ *
+ * @param buffer Pointer to the data buffer
+ * @param size   Number of bytes in the buffer
+ * @return       32-bit CRC of the data
+ */
+uint32_t crc32CalculateBuffer(const void* buffer, size_t size)
+{
+    return crc32ByBit((const uint8_t*)buffer, (uint32_t)size);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -71,6 +71,10 @@ static void mainloop(void);
 #undef BLE
 #endif
 
+#define MEMORY_BITCRAZE_VID 0xBC
+#define MEMORY_AIDECK_PID 0x12
+#define MEMORY_AIDECK_BOARDNAME "bcAI"
+
 #ifdef BLE
 int volatile bleEnabled = 1;
 #else
@@ -115,7 +119,7 @@ int main()
   // To prevent this, we introduce a delay when a specific deck (bcAI) is detected.
 
   // Check if the bcAI deck is attached
-  bool bcAiPresent = memoryHasBcAiDeck();
+  bool bcAiPresent = memoryHasDeck(MEMORY_BITCRAZE_VID, MEMORY_AIDECK_PID, MEMORY_AIDECK_BOARDNAME);
 
   // Apply a delay based on deck presence:
   // - If bcAI is connected, wait 10s to ensure stable operation.

--- a/src/main.c
+++ b/src/main.c
@@ -121,7 +121,7 @@ int main()
   // - If bcAI is connected, wait 10s to ensure stable operation.
   // - Otherwise, skip or use a minimal delay.
   if (bcAiPresent) {
-    msDelay(10000);
+    msDelay(5000);
   } else {
     msDelay(0);
   }

--- a/src/main.c
+++ b/src/main.c
@@ -109,12 +109,22 @@ int main()
   systickInit();
   memoryInit();
 
-  // This is needed to avoid putting the GAP8 into an
-  // undefined state when powering off/on quickly or
-  // moving from bootloader to firmware. Without this
-  // the GAP8 might freeze and needs to be powered off
-  // for a while before recovering.
-  msDelay(10000);
+  // The GAP8 can enter an undefined state if the system is powered off/on too quickly
+  // or transitions directly from the bootloader to firmware. If this happens, the GAP8
+  // might freeze and require a prolonged power-off period to recover.
+  // To prevent this, we introduce a delay when a specific deck (bcAI) is detected.
+
+  // Check if the bcAI deck is attached
+  bool bcAiPresent = memoryHasBcAiDeck();
+
+  // Apply a delay based on deck presence:
+  // - If bcAI is connected, wait 10s to ensure stable operation.
+  // - Otherwise, skip or use a minimal delay.
+  if (bcAiPresent) {
+    msDelay(10000);
+  } else {
+    msDelay(0);
+  }
 
   if (bleEnabled) {
 #ifdef BLE

--- a/src/main.c
+++ b/src/main.c
@@ -114,7 +114,7 @@ int main()
   // moving from bootloader to firmware. Without this
   // the GAP8 might freeze and needs to be powered off
   // for a while before recovering.
-  msDelay(1000);
+  msDelay(10000);
 
   if (bleEnabled) {
 #ifdef BLE

--- a/src/memory.c
+++ b/src/memory.c
@@ -186,11 +186,11 @@ bool memorySyslink(struct syslinkPacket *pk) {
 /**
  * Return true if any discovered deck has:
  *   - Header magic 0xEB at data[0]
- *   - VID = 0xBC at data[5]
- *   - PID = 0x12 at data[6]
- *   - boardName element = "bcAI" in the key/value area
+ *   - Specified VID at data[5]
+ *   - Specified PID at data[6]
+ *   - boardName element matching the provided boardName in the key/value area
  */
-bool memoryHasBcAiDeck(void)
+bool memoryHasDeck(uint8_t vid, uint8_t pid, const char *boardName)
 {
   for (int i = 0; i < nMemory; i++)
   {
@@ -200,8 +200,8 @@ bool memoryHasBcAiDeck(void)
     if (d[0] != 0xEB) {
       continue; // Not a valid Crazyflie deck memory header
     }
-    if (d[5] != 0xBC || d[6] != 0x12) {
-      continue; // Not a deck with the AI-deck's VID/PID
+    if (d[5] != vid || d[6] != pid) {
+      continue; // Not a deck with the specified VID/PID
     }
 
     // 2) key/value parse:
@@ -232,8 +232,8 @@ bool memoryHasBcAiDeck(void)
 
       if (elementId == 1) {
         // Element ID = 1 => boardName (string)
-        // Compare with "bcAI"
-        if (length == 4 && memcmp(&d[offset], "bcAI", 4) == 0) {
+        // Compare with provided boardName
+        if (length == strlen(boardName) && memcmp(&d[offset], boardName, length) == 0) {
           foundBoardName = true;
           // We can break early since we only care about one match
           break;
@@ -245,7 +245,7 @@ bool memoryHasBcAiDeck(void)
     }
 
     if (foundBoardName) {
-      return true; // This deck is the bcAI deck
+      return true; // This deck matches the specified criteria
     }
   }
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -31,6 +31,7 @@
 
 #include "syslink.h"
 
+#include "crc32_calc.h"
 #include "ow.h"
 #include "ownet.h"
 #include "ds2431.h"
@@ -43,6 +44,14 @@ extern int bleEnabled;
 
 #define OW_MAX_CACHED 4
 static struct {unsigned char address[8]; unsigned char data[122];} owCache[OW_MAX_CACHED];
+
+#define DECK_INFO_HEADER_ID       0xEB
+#define DECK_INFO_HEADER_SIZE     7
+#define DECK_INFO_NAME            1
+#define DECK_INFO_TLV_VERSION     0
+#define DECK_INFO_TLV_VERSION_POS 8
+#define DECK_INFO_TLV_LENGTH_POS  9
+#define DECK_INFO_TLV_DATA_POS    10
 
 static void cacheMemory(int nMem)
 {
@@ -182,73 +191,147 @@ bool memorySyslink(struct syslinkPacket *pk) {
   return tx;
 }
 
+#pragma pack(push, 1)
+typedef struct deckInfo_s {
+    union {
+        struct {
+            uint8_t header;
+            uint32_t usedPins;
+            uint8_t vid;
+            uint8_t pid;
+            uint8_t crc;          // CRC of the header (LSB of the 32-bit CRC)
+            uint8_t rawTlv[104];
+        };
+        uint8_t raw[112];
+    };
 
-/**
- * Return true if any discovered deck has:
- *   - Header magic 0xEB at data[0]
- *   - Specified VID at data[5]
- *   - Specified PID at data[6]
- *   - boardName element matching the provided boardName in the key/value area
+    struct {
+        uint8_t* data; // pointer to the TLV data start
+        int length;    // length of the TLV data
+    } tlv;
+} DeckInfo;
+#pragma pack(pop)
+
+
+/*
+ * TLV scanning helpers
  */
+
+static int findType(const uint8_t *tlvData, int tlvLength, int type)
+{
+    int pos = 0;
+    while (pos < tlvLength) {
+        int currentType = tlvData[pos];
+        int lengthField = tlvData[pos + 1];
+        if (currentType == type) {
+            return pos;
+        }
+        // move past this TLV: 1 byte for type, 1 for length, plus payload
+        pos += (2 + lengthField);
+    }
+    return -1;
+}
+
+static bool deckTlvHasElement(const uint8_t *tlvData, int tlvLength, int type)
+{
+    return (findType(tlvData, tlvLength, type) >= 0);
+}
+
+static int deckTlvGetString(const uint8_t *tlvData, int tlvLength, int type,
+                            char *stringOut, int maxLen)
+{
+    int pos = findType(tlvData, tlvLength, type);
+    if (pos < 0) {
+        if (maxLen > 0) {
+            stringOut[0] = '\0';
+        }
+        return -1;
+    }
+
+    int strLen = tlvData[pos + 1];
+    if (strLen >= maxLen) {
+        strLen = maxLen - 1;
+    }
+    memcpy(stringOut, &tlvData[pos + 2], strLen);
+    stringOut[strLen] = '\0';
+
+    return strLen;
+}
+
+// Returns true if a deck with the given vid/pid and board name is found in memory
 bool memoryHasDeck(uint8_t vid, uint8_t pid, const char *boardName)
 {
-  for (int i = 0; i < nMemory; i++)
-  {
-    const unsigned char *d = owCache[i].data;
+    for (int i = 0; i < nMemory; i++) {
+        DeckInfo info;
+        // Copy up to 112 bytes from owCache[i].data
+        memcpy(info.raw, owCache[i].data, sizeof(info.raw));
 
-    // 1) Basic header sanity checks
-    if (d[0] != 0xEB) {
-      continue; // Not a valid Crazyflie deck memory header
-    }
-    if (d[5] != vid || d[6] != pid) {
-      continue; // Not a deck with the specified VID/PID
-    }
-
-    // 2) key/value parse:
-    //    Byte 9 = dataLength. Then from d[10..(10+dataLength-1)]
-    //    we have a series of elements:
-    //      Element format = { element_id (1 byte), length (1 byte), data[] }
-    unsigned int dataLen = d[9];
-    if (dataLen == 0) {
-      // This deck has no key/value pairs
-      continue;
-    }
-
-    // Start parsing at offset = 10
-    unsigned int offset = 10;
-    // We must not exceed the memory we read, so also guard with 10 + dataLen <= 122
-    unsigned int endOffset = (10 + dataLen <= 122) ? (10 + dataLen) : 122;
-
-    bool foundBoardName = false;
-    while (offset + 2 <= endOffset)  // need at least element_id + length
-    {
-      uint8_t elementId = d[offset];
-      uint8_t length    = d[offset + 1];
-      offset += 2;  // move past id and length
-
-      if (offset + length > endOffset) {
-        break; // malformed or truncated
-      }
-
-      if (elementId == 1) {
-        // Element ID = 1 => boardName (string)
-        // Compare with provided boardName
-        if (length == strlen(boardName) && memcmp(&d[offset], boardName, length) == 0) {
-          foundBoardName = true;
-          // We can break early since we only care about one match
-          break;
+        // 1) Check the header
+        if (info.header != DECK_INFO_HEADER_ID) {
+            continue; // Not a valid deck
         }
+
+        // 2) Compute the full 32-bit CRC for the deck info header, then compare its LSB
+        uint32_t fullCrc = crc32CalculateBuffer(info.raw, DECK_INFO_HEADER_SIZE);
+        uint8_t  computed = (uint8_t)(fullCrc & 0xFF);
+        if (info.crc != computed) {
+            // Mismatch
+            continue;
+        }
+
+        // 3) Check vid/pid
+        if (info.vid != vid || info.pid != pid) {
+            continue;
+        }
+
+        // 4) Check the TLV version
+        uint8_t version = info.raw[DECK_INFO_TLV_VERSION_POS];
+        if (version != DECK_INFO_TLV_VERSION) {
+            continue;
+        }
+
+        // 5) Get the length of the TLV block
+        uint8_t tlvLen = info.raw[DECK_INFO_TLV_LENGTH_POS];
+
+        // 6) Setup TLV area
+        info.tlv.data   = &info.raw[DECK_INFO_TLV_DATA_POS];
+        info.tlv.length = tlvLen;
+
+        // 7) Check the TLV CRC
+        //    (Compute a CRC from offset 8 (version) through offset 9+tlvLen,
+        //     then compare its LSB to the byte right after the TLV data)
+        {
+          // Ensure we don’t go out of bounds accessing info.raw[DECK_INFO_TLV_DATA_POS + tlvLen]
+          if ((DECK_INFO_TLV_DATA_POS + tlvLen) < sizeof(info.raw)) {
+              uint8_t storedTlvCrc = info.raw[DECK_INFO_TLV_DATA_POS + tlvLen];
+
+              // Compute a 32-bit CRC on [ version..(version+tlvLen+1) ],
+              // i.e. info.raw[8..(9+tlvLen)], which is (tlvLen + 2) bytes
+              uint32_t computedTlvCrc = crc32CalculateBuffer(
+                  &info.raw[DECK_INFO_TLV_VERSION_POS],
+                  (tlvLen + 2)
+              );
+
+              if ((computedTlvCrc & 0xFF) != storedTlvCrc) {
+                  // TLV region corrupt
+                  continue;
+              }
+          } else {
+              // If there's no room for the stored TLV CRC byte, it's invalid
+              continue;
+          }
       }
 
-      // Move to next element
-      offset += length;
+        // 8) Check for board name in TLV
+        if (deckTlvHasElement(info.tlv.data, info.tlv.length, DECK_INFO_NAME)) {
+            char foundName[64];
+            deckTlvGetString(info.tlv.data, info.tlv.length,
+                             DECK_INFO_NAME, foundName, sizeof(foundName));
+            if (strcmp(foundName, boardName) == 0) {
+                return true;
+            }
+        }
     }
 
-    if (foundBoardName) {
-      return true; // This deck matches the specified criteria
-    }
-  }
-
-  // No matching deck found
-  return false;
+    return false; // not found
 }


### PR DESCRIPTION
PR #69 introduced a 1-second delay before booting the STM32 and decks to prevent the GAP8 from freezing. However, we still saw the issue, even when using only the AI-deck. The severity varied depending on the combination of attached decks.

This PR increases the delay to 5 seconds, which, based on testing, significantly improves stability. However, if issues persist, a further increase may be necessary.

Additionally, this PR ensures that the delayed boot is deck-dependent. Now, the delay is only applied when an AI-deck is attached. To achieve this, we read the OW memory during startup. If no AI-deck is present, the previous 1-second delay is removed entirely.

