### PR TITLE
Reintroduce short boot delay to ensure radio startup reliability

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -127,7 +127,8 @@ int main()
   if (bcAiPresent) {
     msDelay(5000);
   } else {
-    msDelay(0);
+    // Short boot delay needed for stability, reason unknown
+    msDelay(100);
   }
 
   if (bleEnabled) {


### PR DESCRIPTION
A short boot delay was initially introduced in commit 1f498f1bb73628dda2d72cc4ed6df32c53e50c21 to properly initialize the GAP8 on the AI-deck. In PR #102, the delay was removed when no AI-deck was detected to optimize boot time. However, it now appears that the system has started to rely on this delay, as removing it sometimes causes the radio to fail at startup. The exact reason remains unknown, but this commit restores the delay to maintain stability.