### PR TITLE
Adds posibility to clock STM with NRF high precision clock.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ _build/
 
 #Nordic libs etc.
 vendor/
+nrf51_sdk/
+s110/
 
 # jykell files
 docs/.jekyll-metadata

--- a/config.mk.example
+++ b/config.mk.example
@@ -7,3 +7,6 @@
 # OPENOCD_INTERFACE ?= interface/jlink.cfg
 # OPENOCD_TARGET    ?= target/nrf51.cfg
 # OPENOCD_CMDS      ?= -c "set WORKAREASIZE 0" -c "transport select swd"
+
+## Enable 8mhz precision clock to STM32. Only on crazyflie brushless and build with BLE=0
+# CFLAGS += -DENABLE_8MHZ_HSE_CLK_TO_STM

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,5 +8,6 @@ This microcontroller has a couple of roles:
  - Power management (ON/OFF logic and battery handling)
  - Radio communication
    - Enhanced Shockburst compatible with Crazyradio (PA)
-   - Bluetooth low energy using the Nordic Semiconductor S110 stack
+   - Bluetooth low energy using the Nordic Semiconductor S130 stack
  - One-wire memory access
+ - Output a 8mhz high precision clock to STM32 (only on brushless and without BLE).

--- a/interface/pinout.h
+++ b/interface/pinout.h
@@ -117,5 +117,8 @@
 #define STM_SWD_SDIO_MOSI 25
 #define STM_SWD_CLK_CLK 28
 
+// Routed on CF21BL only but not conflicting on other boards.
+#define STM_HSE_CLK_PIN   23
+
 #endif //__PINOUT_H__
 

--- a/interface/systick.h
+++ b/interface/systick.h
@@ -24,8 +24,14 @@
 #ifndef __SYSTICK_H__
 #define __SYSTICK_H__
 
+/**
+ * Initialize the systick timer. The systick will increment a tick count every 1ms.
+ */
 void systickInit();
 
+/**
+ * Return the current tick count. The tick is incremented every 1ms.
+ */
 unsigned int systickGetTick();
 
 #endif //__SYSTICK_H__

--- a/src/pm.c
+++ b/src/pm.c
@@ -200,16 +200,21 @@ static void enable8MHzClockToSTM(void)
                           STM_HSE_CLK_PIN << GPIOTE_CONFIG_PSEL_Pos | 
                           GPIOTE_CONFIG_OUTINIT_Low << GPIOTE_CONFIG_OUTINIT_Pos;
                           
+  // Ensure TIMER0 is in a known state before configuring and starting it.
+  NRF_TIMER0->TASKS_STOP = 1;
+  NRF_TIMER0->TASKS_CLEAR = 1;
+  NRF_TIMER0->EVENTS_COMPARE[0] = 0;
+   
   NRF_TIMER0->PRESCALER = 0;
   // Adjust the output frequency by adjusting the CC. 
   NRF_TIMER0->CC[0] = 1;
-  NRF_TIMER0->SHORTS = TIMER_SHORTS_COMPARE0_CLEAR_Enabled << TIMER_SHORTS_COMPARE0_CLEAR_Pos;
+  NRF_TIMER0->SHORTS = TIMER_SHORTS_COMPARE0_CLEAR_Msk;
   NRF_TIMER0->TASKS_START = 1;
 
   NRF_PPI->CH[2].EEP = (uint32_t) &NRF_TIMER0->EVENTS_COMPARE[0];
   NRF_PPI->CH[2].TEP = (uint32_t) &NRF_GPIOTE->TASKS_OUT[0];
 
-  NRF_PPI->CHENSET = PPI_CHENSET_CH2_Enabled << PPI_CHENSET_CH2_Pos;
+  NRF_PPI->CHENSET = PPI_CHENSET_CH2_Msk;
 }
 #endif
 

--- a/src/pm.c
+++ b/src/pm.c
@@ -45,6 +45,10 @@
 
 //#define ENABLE_FAST_CHARGE_1A
 //#define RFX2411N_BYPASS_MODE
+#if defined(ENABLE_8MHZ_HSE_CLK_TO_STM) && defined(BLE)
+  #error "Can't enable 8MHz HSE clock to STM when BLE is enabled due to resource conflict."
+#endif
+
 
 extern int bleEnabled;
 
@@ -185,47 +189,34 @@ static void pmDummy(bool enable) {
   ;
 }
 
-#if 0
-#ifndef BLE
-#define OUTPUT_PIN_NUMBER   23
-static void enable8MHzHLCKtoSTM(void)
+#ifdef ENABLE_8MHZ_HSE_CLK_TO_STM
+static void enable8MHzClockToSTM(void)
 {
-  // Configure OUTPUT_PIN_NUMBER as an output.
-  nrf_gpio_cfg_output(OUTPUT_PIN_NUMBER);
+  nrf_gpio_cfg_output(STM_HSE_CLK_PIN);
 
-  // Configure GPIOTE channel 0 to toggle the pin state
-  nrf_gpiote_task_config(0, OUTPUT_PIN_NUMBER,
-                         NRF_GPIOTE_POLARITY_TOGGLE,
-                         NRF_GPIOTE_INITIAL_VALUE_LOW);
+  NRF_GPIOTE->CONFIG[0] = GPIOTE_CONFIG_MODE_Task << GPIOTE_CONFIG_MODE_Pos |
+                          GPIOTE_CONFIG_POLARITY_Toggle << GPIOTE_CONFIG_POLARITY_Pos |
+                          STM_HSE_CLK_PIN << GPIOTE_CONFIG_PSEL_Pos | 
+                          GPIOTE_CONFIG_OUTINIT_Low << GPIOTE_CONFIG_OUTINIT_Pos;
+                          
+  NRF_TIMER0->PRESCALER = 0;
+  // Adjust the output frequency by adjusting the CC. 
+  NRF_TIMER0->CC[0] = 1;
+  NRF_TIMER0->SHORTS = TIMER_SHORTS_COMPARE0_CLEAR_Enabled << TIMER_SHORTS_COMPARE0_CLEAR_Pos;
+  NRF_TIMER0->TASKS_START = 1;
 
-  // Configure PPI channel 2 to toggle OUTPUT_PIN on every TIMER1 COMPARE[0] match.
-  NRF_PPI->CH[2].EEP = (uint32_t)&NRF_TIMER1->EVENTS_COMPARE[0];
-  NRF_PPI->CH[2].TEP = (uint32_t)&NRF_GPIOTE->TASKS_OUT[0];
+  NRF_PPI->CH[2].EEP = (uint32_t) &NRF_TIMER0->EVENTS_COMPARE[0];
+  NRF_PPI->CH[2].TEP = (uint32_t) &NRF_GPIOTE->TASKS_OUT[0];
 
-  // Enable PPI channel 2
-  NRF_PPI->CHEN = (PPI_CHEN_CH2_Enabled << PPI_CHEN_CH2_Pos);
-
-  // Configure timer 2
-  NRF_TIMER1->TASKS_STOP = 1;
-  NRF_TIMER1->TASKS_CLEAR = 1;
-  NRF_TIMER1->MODE      = TIMER_MODE_MODE_Timer;
-  NRF_TIMER1->BITMODE   = TIMER_BITMODE_BITMODE_16Bit << TIMER_BITMODE_BITMODE_Pos;
-  NRF_TIMER1->PRESCALER = 0;
-  NRF_TIMER1->SHORTS = TIMER_SHORTS_COMPARE0_CLEAR_Msk;
-  NRF_TIMER1->INTENSET = 0;
-  NVIC_DisableIRQ(TIMER1_IRQn);
-  // Load the initial values to TIMER1 CC registers to get 8Mhz.
-  NRF_TIMER1->CC[0] = 1;
-  NRF_TIMER1->TASKS_START = 1;
+  NRF_PPI->CHENSET = PPI_CHENSET_CH2_Enabled << PPI_CHENSET_CH2_Pos;
 }
-#endif
 #endif
 
 static void pmPowerSystem(bool enable)
 {
   if (enable) {
-#ifndef BLE
-//    enable8MHzHLCKtoSTM();
+#ifdef ENABLE_8MHZ_HSE_CLK_TO_STM
+    enable8MHzClockToSTM();
 #endif
     NRF_GPIO->PIN_CNF[STM_NRST_PIN] = (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos)
                                       | (GPIO_PIN_CNF_DRIVE_S0D1 << GPIO_PIN_CNF_DRIVE_Pos)

--- a/src/pm.c
+++ b/src/pm.c
@@ -45,6 +45,7 @@
 
 //#define ENABLE_FAST_CHARGE_1A
 //#define RFX2411N_BYPASS_MODE
+
 #if defined(ENABLE_8MHZ_HSE_CLK_TO_STM) && defined(BLE)
   #error "Can't enable 8MHz HSE clock to STM when BLE is enabled due to resource conflict."
 #endif
@@ -226,6 +227,9 @@ static void pmPowerSystem(bool enable)
     nrf_gpio_pin_clear(STM_NRST_PIN); //Hold STM reset
     nrf_gpio_pin_set(PM_VCCEN_PIN);
   } else {
+#ifdef ENABLE_8MHZ_HSE_CLK_TO_STM
+    nrf_gpio_cfg_input(STM_HSE_CLK_PIN, NRF_GPIO_PIN_NOPULL);
+#endif
     nrf_gpio_cfg_input(STM_NRST_PIN, NRF_GPIO_PIN_PULLDOWN);
     nrf_gpio_pin_clear(PM_VCCEN_PIN);
   }


### PR DESCRIPTION
This pull request introduces compile time support for driving the STM32 HSE with an 8MHz high-precision clock from the NRF51. This is usefull when the 0.1% precision clock on the STM32 is not enough, e.g. in larger swarms when the clocks needs to be very synced.

This is only applicable on the Crazyflie brushless (this is the only plattform where this signal is routed) when BLE is disabled (compile time check). On the other platforms this pin is unconnected so nothing will break if it is enabled by mistake.

Some minor documentation of how to enable it has been added.