### PR TITLE
Fix for 1-wire timout if two decks where attached and STM wake-up was called.

### DIFF
--- a/interface/syslink.h
+++ b/interface/syslink.h
@@ -27,8 +27,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define SYSLINK_STARTUP_DELAY_TIME_MS 1000
-#define SYSLINK_SEND_PERIOD_MS 10
+#define SYSLINK_STARTUP_DELAY_TIME_MS     1000
+#define SYSLINK_SEND_PERIOD_MS            10
+#define SYSLINK_RADIO_DISABLED_TIMEOUT_MS 3000
 
 #define SYSLINK_MTU 64
 

--- a/src/main.c
+++ b/src/main.c
@@ -103,6 +103,7 @@ static bool debugProbeReceivedAddress = false;
 static bool debugProbeReceivedRate = false;
 
 static bool radioReadyCommandReceived = false;
+static uint32_t sysonTime = 0;
 
 int main()
 {
@@ -212,7 +213,8 @@ void mainloop()
       }
 
       // Check if we should open the gate
-      if (radioReadyCommandReceived || (systickGetTick() >= startupTime + 3000)) {
+      if (radioReadyCommandReceived || 
+           (systickGetTick() >= startupTime + SYSLINK_RADIO_DISABLED_TIMEOUT_MS)) {
         esbAllowStart();
         radioStartupGateHandled = true;
       }
@@ -267,7 +269,8 @@ void mainloop()
       {
         // Radio packet, send it to STM32 over syslink.
         // Do it first when the STM is ready to receive it.
-        if  (radioReadyCommandReceived)
+        if  (radioReadyCommandReceived || 
+              (systickGetTick() >= sysonTime + SYSLINK_RADIO_DISABLED_TIMEOUT_MS))
         {
           if (p2p == false) {
             memcpy(slTxPacket.data, packet->data, packet->size);
@@ -661,6 +664,7 @@ static void handleBootloaderCmd(struct esbPacket_s *packet)
       pmSysBootloader(false);
       syslinkReset();
       radioReadyCommandReceived = false;
+      sysonTime = systickGetTick();
       pmSetState(pmSysRunning);
       break;
     case BOOTLOADER_CMD_GETVBAT:

--- a/src/main.c
+++ b/src/main.c
@@ -265,27 +265,32 @@ void mainloop()
       }
       else
       {
-        if (p2p == false) {
-          memcpy(slTxPacket.data, packet->data, packet->size);
-          slTxPacket.length = packet->size;
-          if (broadcast) {
-            slTxPacket.type = SYSLINK_RADIO_RAW_BROADCAST;
+        // Radio packet, send it to STM32 over syslink.
+        // Do it first when the STM is ready to receive it.
+        if  (radioReadyCommandReceived)
+        {
+          if (p2p == false) {
+            memcpy(slTxPacket.data, packet->data, packet->size);
+            slTxPacket.length = packet->size;
+            if (broadcast) {
+              slTxPacket.type = SYSLINK_RADIO_RAW_BROADCAST;
+            } else {
+              slTxPacket.type = SYSLINK_RADIO_RAW;
+            }
           } else {
-            slTxPacket.type = SYSLINK_RADIO_RAW;
+            // The first byte sent is the P2P port
+            slTxPacket.data[0] = packet->data[1] & 0x0F;
+            slTxPacket.data[1] = packet->rssi; // Save RSSI between drones in packet
+            memcpy(&slTxPacket.data[2], &packet->data[2], packet->size-2);
+            slTxPacket.length = packet->size;
+            if (broadcast) {
+              slTxPacket.type = SYSLINK_RADIO_P2P_BROADCAST;
+            } else {
+              slTxPacket.type = SYSLINK_RADIO_P2P;
+            }
           }
-        } else {
-          // The first byte sent is the P2P port
-          slTxPacket.data[0] = packet->data[1] & 0x0F;
-          slTxPacket.data[1] = packet->rssi; // Save RSSI between drones in packet
-          memcpy(&slTxPacket.data[2], &packet->data[2], packet->size-2);
-          slTxPacket.length = packet->size;
-          if (broadcast) {
-            slTxPacket.type = SYSLINK_RADIO_P2P_BROADCAST;
-          } else {
-            slTxPacket.type = SYSLINK_RADIO_P2P;
-          }
+          syslinkSend(&slTxPacket);
         }
-        syslinkSend(&slTxPacket);
       }
     }
 
@@ -654,9 +659,9 @@ static void handleBootloaderCmd(struct esbPacket_s *packet)
       break;
     case BOOTLOADER_CMD_SYSON:
       pmSysBootloader(false);
-      pmSetState(pmSysRunning);
       syslinkReset();
-
+      radioReadyCommandReceived = false;
+      pmSetState(pmSysRunning);
       break;
     case BOOTLOADER_CMD_GETVBAT:
       if (esbCanTxPacket()) {


### PR DESCRIPTION
This pull request updates the handling of radio packets and the bootloader command flow in `src/main.c` to improve synchronization between the radio and STM32 communication. The main changes ensure that radio packets are only sent when the STM32 is ready and reset the radio readiness state appropriately after certain bootloader commands.

* Radio packets are now only sent to the STM32 over syslink if the `radioReadyCommandReceived` flag is set, ensuring that the STM32 is ready to receive them.

* When handling the `BOOTLOADER_CMD_SYSON` command, the `radioReadyCommandReceived` flag is now reset to `false` before setting the system state to running, ensuring correct initialization after bootloader operations.