### PR TITLE
Handle all null CRTP platform packets in the radio interrupt

### DIFF
--- a/interface/pm.h
+++ b/interface/pm.h
@@ -37,6 +37,10 @@ uint8_t getPowerStatusFlags();
 
 float pmGetVBAT(void);
 
+/* Get pre-built battery voltage response packet for direct radio ACK */
+uint8_t* pmGetVbatPacket(void);
+uint8_t pmGetVbatPacketSize(void);
+
 float pmGetISET(void);
 
 float pmGetTemp(void);

--- a/interface/pm.h
+++ b/interface/pm.h
@@ -38,7 +38,7 @@ uint8_t getPowerStatusFlags();
 float pmGetVBAT(void);
 
 /* Get pre-built battery voltage response packet for direct radio ACK */
-uint8_t* pmGetVbatPacket(void);
+const uint8_t* pmGetVbatPacket(void);
 uint8_t pmGetVbatPacketSize(void);
 
 float pmGetISET(void);

--- a/src/esb.c
+++ b/src/esb.c
@@ -210,6 +210,35 @@ void esbInterruptHandler()
       pk->crc = NRF_RADIO->RXCRC;
       pk->match = NRF_RADIO->RXMATCH;
 
+      // The following handlers respond directly in the interrupt and do
+      // not need a slot in the RX queue. They must be checked before the
+      // queue-full guard so that they remain reachable even when the
+      // queue is full.
+
+      // Answer battery voltage query directly in the ACK via servicePacket
+      if (pk->match == ESB_UNICAST_ADDRESS_MATCH &&
+          pk->size >= 3 && (pk->data[0] & 0xf3) == 0xf3 &&
+          pk->data[1] == 0xfe && pk->data[2] == 0x04) {
+        memcpy(servicePacket.data, pmGetVbatPacket(), pmGetVbatPacketSize());
+        servicePacket.size = pmGetVbatPacketSize();
+        setupTx(false, false);
+        return;
+      }
+
+      // Match safeLink packet and answer it
+      if (pk->match == ESB_UNICAST_ADDRESS_MATCH &&
+          pk->size == 3 && (pk->data[0]&0xf3) == 0xf3 && pk->data[1] == 0x05) {
+        has_safelink = pk->data[2];
+        memcpy(servicePacket.data, pk->data, 3);
+        servicePacket.size = 3;
+        setupTx(false, false);
+
+        // Reset packet counters
+        curr_down = 1;
+        curr_up = 1;
+        return;
+      }
+
       // If no more space available on RX queue, drop packet!
       if (((rxq_head+1)%RXQ_LEN) == rxq_tail) {
         NRF_RADIO->TASKS_START = 1UL;
@@ -224,16 +253,6 @@ void esbInterruptHandler()
         // Push the queue head to push this packet and prepare the next
         // The main loop will recognize it as a P2P packet
         rxq_head = ((rxq_head+1)%RXQ_LEN);
-        return;
-      }
-
-      // Answer battery voltage query directly in the ACK via servicePacket
-      if (pk->match == ESB_UNICAST_ADDRESS_MATCH &&
-          pk->size >= 3 && (pk->data[0] & 0xf3) == 0xf3 &&
-          pk->data[1] == 0xfe && pk->data[2] == 0x04) {
-        memcpy(servicePacket.data, pmGetVbatPacket(), pmGetVbatPacketSize());
-        servicePacket.size = pmGetVbatPacketSize();
-        setupTx(false, false);
         return;
       }
 
@@ -261,19 +280,6 @@ void esbInterruptHandler()
 
       if ((pk->match == ESB_UNICAST_ADDRESS_MATCH))
       {
-        // Match safeLink packet and answer it
-        if (pk->size == 3 && (pk->data[0]&0xf3) == 0xf3 && pk->data[1] == 0x05) {
-          has_safelink = pk->data[2];
-          memcpy(servicePacket.data, pk->data, 3);
-          servicePacket.size = 3;
-          setupTx(false, false);
-
-          // Reset packet counters
-          curr_down = 1;
-          curr_up = 1;
-          return;
-        }
-
         // Drop unhandled null CRTP platform packets directly in the
         // interrupt. These are never forwarded to the main loop or the
         // STM32. An empty ACK is sent back so that no connection data

--- a/src/esb.c
+++ b/src/esb.c
@@ -35,9 +35,7 @@
 
 //#define RSSI_VBAT_ACK_PACKET
 
-#ifdef RSSI_VBAT_ACK_PACKET
-  #include "pm.h"
-#endif
+#include "pm.h"
 
 #define RXQ_LEN 8
 #define TXQ_LEN 8
@@ -229,6 +227,16 @@ void esbInterruptHandler()
         return;
       }
 
+      // Answer battery voltage query directly in the ACK via servicePacket
+      if (pk->match == ESB_UNICAST_ADDRESS_MATCH &&
+          pk->size >= 3 && (pk->data[0] & 0xf3) == 0xf3 &&
+          pk->data[1] == 0xfe && pk->data[2] == 0x04) {
+        memcpy(servicePacket.data, pmGetVbatPacket(), pmGetVbatPacketSize());
+        servicePacket.size = pmGetVbatPacketSize();
+        setupTx(false, false);
+        return;
+      }
+
       // Ack Bootloader packets right away with regular ack
       if (pk->match == ESB_UNICAST_ADDRESS_MATCH &&
           pk->size >= 2 && (pk->data[0] & 0xf3) == 0xf3 && pk->data[1] == 0xfe) {
@@ -236,6 +244,17 @@ void esbInterruptHandler()
 
         // Push the queue head to push this packet and prepare the next
         // The main loop will recognize it as a bootloader packet
+        rxq_head = ((rxq_head+1)%RXQ_LEN);
+        return;
+      }
+
+      // Ack Radio command packets right away with empty ack
+      if (pk->match == ESB_UNICAST_ADDRESS_MATCH &&
+          pk->size >= 4 && (pk->data[0] & 0xf3) == 0xf3 && pk->data[1] == 0x03) {
+        setupTx(false, true);
+
+        // Push the queue head to push this packet and prepare the next
+        // The main loop will handle the radio command
         rxq_head = ((rxq_head+1)%RXQ_LEN);
         return;
       }
@@ -252,6 +271,15 @@ void esbInterruptHandler()
           // Reset packet counters
           curr_down = 1;
           curr_up = 1;
+          return;
+        }
+
+        // Drop unhandled null CRTP platform packets directly in the
+        // interrupt. These are never forwarded to the main loop or the
+        // STM32. An empty ACK is sent back so that no connection data
+        // from the TX queue is leaked.
+        if (pk->size >= 2 && (pk->data[0] & 0xf3) == 0xf3) {
+          setupTx(false, true);
           return;
         }
 

--- a/src/pm.c
+++ b/src/pm.c
@@ -22,6 +22,7 @@
  * License along with this library.
  */
 #include <stdbool.h>
+#include <string.h>
 
 #include <nrf.h>
 #include <nrf_gpio.h>
@@ -72,6 +73,10 @@ static ADCState adcState = adcVBAT;
 static float vBat;
 static float iSet;
 static float temp;
+
+// Pre-built battery voltage response packet for direct ACK in radio interrupt
+static uint8_t vbatResponsePacket[7] = {0xff, 0xfe, 0x04, 0, 0, 0, 0};
+static uint8_t vbatResponseSize = 7;
 
 void pmInit()
 {
@@ -396,6 +401,14 @@ float pmGetVBAT(void) {
 	return vBat;
 }
 
+uint8_t* pmGetVbatPacket(void) {
+  return vbatResponsePacket;
+}
+
+uint8_t pmGetVbatPacketSize(void) {
+  return vbatResponseSize;
+}
+
 float pmGetISET(void) {
   return iSet;
 }
@@ -455,6 +468,7 @@ void pmProcess() {
 
 	  if (adcState == adcVBAT) {
 		  vBat = (float) (rawValue / 1023.0) * 1.2 * pmConfig->vbatFactor;
+		  memcpy(&vbatResponsePacket[3], &vBat, sizeof(float));
 		  if (pmConfig->hasCharger) {
 		    pmStartAdc(adcISET);
 		  } else {

--- a/src/pm.c
+++ b/src/pm.c
@@ -76,7 +76,7 @@ static float temp;
 
 // Pre-built battery voltage response packet for direct ACK in radio interrupt
 static uint8_t vbatResponsePacket[7] = {0xff, 0xfe, 0x04, 0, 0, 0, 0};
-static uint8_t vbatResponseSize = 7;
+static uint8_t vbatResponseSize = sizeof(vbatResponsePacket);
 
 void pmInit()
 {
@@ -401,7 +401,7 @@ float pmGetVBAT(void) {
 	return vBat;
 }
 
-uint8_t* pmGetVbatPacket(void) {
+const uint8_t* pmGetVbatPacket(void) {
   return vbatResponsePacket;
 }
 
@@ -468,7 +468,9 @@ void pmProcess() {
 
 	  if (adcState == adcVBAT) {
 		  vBat = (float) (rawValue / 1023.0) * 1.2 * pmConfig->vbatFactor;
+		  __disable_irq();
 		  memcpy(&vbatResponsePacket[3], &vBat, sizeof(float));
+		  __enable_irq();
 		  if (pmConfig->hasCharger) {
 		    pmStartAdc(adcISET);
 		  } else {


### PR DESCRIPTION
All null CRTP packets (data[0] & 0xF3 == 0xF3, size >= 2) are now intercepted in the radio interrupt handler and never reach safelink processing or the STM32 application processor. This establishes a clean model where the nRF handles platform-level commands at the radio layer.

This builds a framework for future platform-level packets that will not make it to the STM32 and not affect syslink-protected connections.

Packet routing in the interrupt:
- P2P (0x80-0x8F): empty ACK, queued for main loop
- Battery voltage (0xFE + 0x04): immediate response via servicePacket using a pre-built packet updated every ADC cycle (~100Hz)
- Bootloader (0xFE, other): regular ACK, queued for main loop
- Radio commands (0x03): empty ACK, queued for main loop (moved out of safelink processing since no client relies on safelink for these)
- Safelink init (0x05): servicePacket response, not queued
- Any other null packet: empty ACK, silently dropped

Empty ACKs are used for platform packets that don't have a specific response, ensuring no connection data from the TX queue is leaked to the sender.