### PR TITLE
Fix fetch-dependencies script

### DIFF
--- a/tools/fetch-dependencies.sh
+++ b/tools/fetch-dependencies.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
The shebang is not on the first line of the fetch-dependencies script, which makes the script fallback to dash, for which popd is not implemented. Put shebang on first line to make it work.