### PR TITLE
Turn the radio off while charging when the STM32 asks for it

### DIFF
--- a/interface/pm.h
+++ b/interface/pm.h
@@ -35,6 +35,9 @@ void pmInit();
 /* Return power flags that indicate if we're plugged in to USB, currently charging and if we can charge. */
 uint8_t getPowerStatusFlags();
 
+/* Return true if USB is plugged in. Always false on platforms without a charger (such as Bolt). */
+bool pmIsUsbPluggedIn();
+
 float pmGetVBAT(void);
 
 /* Get pre-built battery voltage response packet for direct radio ACK */

--- a/interface/syslink.h
+++ b/interface/syslink.h
@@ -93,6 +93,7 @@ uint8_t syslinkGetRxCheckSum2ErrorCnt();
 #define SYSLINK_RADIO_P2P_ACK       0x09
 #define SYSLINK_RADIO_P2P_BROADCAST 0x0A
 #define SYSLINK_RADIO_READY         0x0B
+#define SYSLINK_RADIO_DISABLE_ON_USB 0x0C
 
 
 #define SYSLINK_PM_SOURCE             0x10

--- a/src/main.c
+++ b/src/main.c
@@ -105,6 +105,10 @@ static bool debugProbeReceivedRate = false;
 static bool radioReadyCommandReceived = false;
 static uint32_t sysonTime = 0;
 
+// Set by the STM32, cleared on system restart to keep the bootloader reachable
+static bool disableRadioOnUsb = false;
+static bool radioIsDisabled = false;
+
 int main()
 {
   // Stop early if the platform is not supported
@@ -204,6 +208,8 @@ void mainloop()
   static bool radioStartupGateHandled = false;
   static uint32_t startupTime = 0;
 
+  static PmState lastPmState = pmSysOff;
+
   while(1)
   {
     // Handle radio startup gate (only once)
@@ -213,10 +219,34 @@ void mainloop()
       }
 
       // Check if we should open the gate
-      if (radioReadyCommandReceived || 
+      if (radioReadyCommandReceived ||
            (systickGetTick() >= startupTime + SYSLINK_RADIO_DISABLED_TIMEOUT_MS)) {
         esbAllowStart();
         radioStartupGateHandled = true;
+      }
+    }
+
+    // The STM32 is going down or restarting, drop its policy. It resends it on boot.
+    PmState pmState = pmGetState();
+    if (pmState != lastPmState) {
+      lastPmState = pmState;
+      disableRadioOnUsb = false;
+    }
+
+    // Turn the radio off while charging, if the STM32 asked for it
+    if (radioStartupGateHandled) {
+      bool shouldDisable = disableRadioOnUsb && pmIsUsbPluggedIn();
+
+      if (shouldDisable != radioIsDisabled) {
+        radioIsDisabled = shouldDisable;
+        if (shouldDisable) {
+          // Take the radio back from the softdevice before powering it off
+          disableBle();
+          esbDeinit();
+        } else {
+          esbInit();
+          esbAllowStart();
+        }
       }
     }
 #ifdef BLE
@@ -469,6 +499,9 @@ static void handleSyslinkEvents(bool slReceived)
         slTxPacket.type = SYSLINK_RADIO_READY;
         slTxPacket.length = 0;
         syslinkSend(&slTxPacket);
+        break;
+      case SYSLINK_RADIO_DISABLE_ON_USB:
+        disableRadioOnUsb = (slRxPacket.length >= 1) && (slRxPacket.data[0] != 0);
         break;
       case SYSLINK_PM_DECKCTRL_DFU:
         pmDeckctrlDfu(slRxPacket.data[0]);

--- a/src/pm.c
+++ b/src/pm.c
@@ -104,6 +104,11 @@ uint8_t pmIsCharging() {
   return nrf_gpio_pin_read(PM_CHG_PIN);
 }
 
+bool pmIsUsbPluggedIn() {
+  // 'pGood' means valid input voltage from USB and is active LOW
+  return pmConfig->hasCharger && !pmPGood();
+}
+
 uint8_t getPowerStatusFlags() {
   power_flag_t powerFlags;
   uint8_t isCharging = pmIsCharging();


### PR DESCRIPTION
**Paired with: bitcraze/crazyflie-firmware#1658**

Crazyflie drones have to be powered on to charge, so drones sitting on a charging rack answer radio scans exactly like flight-ready ones. This costs time, and a charging drone can unintentionally be sent flight commands. The ACK that makes a drone appear in a scan is generated by the radio here, so the STM32 cannot do anything about it on its own.

**Fix:**
Handle a new `SYSLINK_RADIO_DISABLE_ON_USB` (`0x0C`) carrying the user's preference from the STM32 (the new `disableRadioOnUsb` param from the above-mentioned PR). The rule itself is applied here, since the nRF51 owns both the radio and the USB detection, it is the one reporting `usbPluggedIn` in `SYSLINK_PM_BATTERY_STATE`. `esbDeinit()` already does exactly what is needed (`NRF_RADIO->POWER = 0`) and is already exercised by the BLE timeslot code.

Also adds `pmIsUsbPluggedIn()`: `!pmPGood()` guarded by `pmConfig->hasCharger`, so it stays `false` on platforms where the nRF51 cannot detect USB (Bolt for example) and the feature is simply inert there.

Before the fix:
charging drone -> detected in a scan and answers like a flight-ready drone

After the fix (with both the STM32 and the nRF51 flashed):
charging drone -> same as a powered-off drone, and radio back on unplug without a reboot

Inert on its own: nothing sends `SYSLINK_RADIO_DISABLE_ON_USB` until the STM32 PR lands, so the two can be merged in any order.